### PR TITLE
Changed --force to -f for OSX compatibility

### DIFF
--- a/deploy
+++ b/deploy
@@ -14,7 +14,7 @@ fi
 cd "`dirname $0`"
 
 tmp=.upload.tar.gz
-rm --force $tmp
+rm -f $tmp
 tar --create --gzip --file $tmp --exclude-from .deployignore *
 	# .* is not included
 


### PR DESCRIPTION
The --force flag doesn't exist on OS X (see https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/rm.1.html) and gives the following error:
```
rm: illegal option -- -
usage: rm [-f | -i] [-dPRrvW] file ...
       unlink file
```